### PR TITLE
Find vbuf input connected to another vbuf output

### DIFF
--- a/VBUF_SELECT_SOLUTION.md
+++ b/VBUF_SELECT_SOLUTION.md
@@ -1,0 +1,61 @@
+# VBUF器件连接关系查找 - Yosys Select指令解决方案
+
+## 问题描述
+查找符合以下条件的VBUF器件实例：
+- VBUF的输入端口I直接连接到另一个VBUF的输出端口O
+- 中间不存在任何其他器件
+
+## 解决方案
+
+### 推荐的Select指令
+```yosys
+select t:VBUF %x1:+[O] w:* %x1:+[I],VBUF t:VBUF %i
+```
+
+### 指令解析
+1. `t:VBUF` - 选择所有类型为VBUF的器件
+2. `%x1:+[O]` - 通过输出端口O扩展选择1步，找到连接的线网
+3. `w:* %i` - 与所有线网求交集，确保选择的是线网
+4. `%x1:+[I],VBUF` - 通过这些线网扩展选择1步，只通过VBUF器件的输入端口I
+5. `t:VBUF %i` - 与VBUF器件类型求交集，确保最终只选择VBUF器件
+
+### 关键点说明
+- `%x1` 确保只扩展1步，保证是直接连接（中间无其他器件）
+- `+[O]` 指定只通过输出端口O进行扩展
+- `+[I],VBUF` 指定只通过VBUF器件的输入端口I进行扩展
+- 最后的 `t:VBUF %i` 确保结果只包含VBUF器件
+
+### 分步方法（用于调试和理解）
+```yosys
+# 保存所有VBUF器件
+select -set all_vbuf t:VBUF
+
+# 找到VBUF输出连接的线网
+select @all_vbuf %x1:+[O] w:* %i
+select -set vbuf_output_nets %
+
+# 找到连接到这些线网的VBUF输入端口
+select @vbuf_output_nets %x1:+[I],VBUF t:VBUF %i
+```
+
+### 使用示例
+在测试电路中，如果有以下连接：
+```
+VBUF vbuf1 (.I(input_sig), .O(net1));
+VBUF vbuf2 (.I(net1), .O(net2));        // 应该被选中
+VBUF vbuf3 (.I(net2), .O(net3));        // 应该被选中
+```
+
+select指令将选中vbuf2和vbuf3，因为它们的输入端口I直接连接到其他VBUF的输出端口O。
+
+### 验证方法
+可以使用以下命令验证结果：
+```yosys
+select -count    # 显示选中的器件数量
+ls               # 列出选中的器件
+```
+
+## 文件说明
+- `vbuf_select_example.ys` - 完整的解决方案示例
+- `vbuf_test.v` - 测试用的Verilog文件
+- `test_vbuf_select.ys` - 验证脚本

--- a/test_vbuf_select.ys
+++ b/test_vbuf_select.ys
@@ -1,0 +1,70 @@
+# Yosys测试脚本：验证VBUF连接关系的select指令
+# 
+
+# 读取Verilog文件
+read_verilog vbuf_test.v
+
+# 进入测试模块
+cd test_vbuf_connections
+
+# 显示所有VBUF器件
+echo "所有VBUF器件："
+select t:VBUF
+ls
+
+# 清除选择
+select -clear
+
+echo "=============================================="
+echo "查找输入端口I直接连接到其他VBUF输出端口O的VBUF器件："
+echo ""
+
+# 方法1：基本方法
+echo "方法1 - 基本扩展选择："
+select t:VBUF %x1:+[O] w:* %x1:+[I],VBUF t:VBUF %i
+ls
+echo "选中的器件数量："
+select -count
+
+echo ""
+echo "=============================================="
+
+# 清除选择
+select -clear
+
+# 方法2：更详细的分步方法
+echo "方法2 - 分步分析："
+
+# 步骤1：保存所有VBUF
+select -set all_vbuf t:VBUF
+echo "步骤1 - 所有VBUF器件："
+select @all_vbuf
+ls
+
+# 步骤2：找到所有VBUF的输出线网
+select @all_vbuf %x1:+[O] w:* %i
+select -set vbuf_output_nets %
+echo "步骤2 - VBUF输出连接的线网："
+select @vbuf_output_nets
+ls
+
+# 步骤3：找到连接到这些线网的VBUF输入端口
+select @vbuf_output_nets %x1:+[I],VBUF t:VBUF %i
+echo "步骤3 - 最终结果（输入端口I连接到其他VBUF输出的VBUF器件）："
+ls
+echo "选中的器件数量："
+select -count
+
+echo ""
+echo "=============================================="
+
+# 验证结果：应该选中vbuf2, vbuf3, vbuf4
+# vbuf1不应该被选中（它的输入没有连接到其他VBUF的输出）
+# vbuf5不应该被选中（它的输出没有连接到其他VBUF的输入）
+# vbuf6不应该被选中（它的输入没有连接到其他VBUF的输出）
+
+echo "验证：期望结果应该包含 vbuf2, vbuf3, vbuf4"
+echo "因为："
+echo "- vbuf2的输入I连接到vbuf1的输出O"
+echo "- vbuf3的输入I连接到vbuf2的输出O"  
+echo "- vbuf4的输入I连接到vbuf3的输出O"

--- a/vbuf_select_example.ys
+++ b/vbuf_select_example.ys
@@ -1,0 +1,48 @@
+# Yosys select指令示例：查找VBUF器件连接关系
+# 
+# 目标：查找VBUF器件实例，其输入端口I直接连接到另一个VBUF的输出端口O
+#
+# 解决方案分析：
+# 1. 首先选择所有VBUF类型的器件
+# 2. 通过输出端口O扩展选择，找到连接的线网
+# 3. 再通过这些线网扩展选择，找到连接到这些线网的VBUF输入端口I
+# 4. 排除原始选择的VBUF，得到目标VBUF
+
+# 方法1：使用%x扩展选择来查找连接关系
+# 选择所有VBUF类型的器件，通过输出端口O扩展，再通过输入端口I扩展，找到连接的VBUF
+select t:VBUF %x:+[O] %x:+[I],VBUF t:VBUF %i
+
+# 解释：
+# t:VBUF           - 选择所有类型为VBUF的器件
+# %x:+[O]          - 扩展选择：通过VBUF的输出端口O连接的线网
+# %x:+[I],VBUF     - 扩展选择：通过这些线网连接到VBUF器件的输入端口I
+# t:VBUF %i        - 与VBUF器件类型求交集，确保只选择VBUF器件
+
+# 方法2：更精确的方法，使用保存选择
+# 先保存所有VBUF的选择
+select -set all_vbuf t:VBUF
+
+# 选择所有VBUF的输出端口O连接的线网
+select @all_vbuf %x:+[O] w:* %i
+select -set vbuf_output_nets %
+
+# 选择连接到这些线网的VBUF输入端口I
+select @vbuf_output_nets %x:+[I],VBUF t:VBUF %i
+
+# 这将选择所有输入端口I直接连接到其他VBUF输出端口O的VBUF器件
+
+# 方法3：使用输出锥和输入锥
+# 选择所有VBUF，通过输出锥扩展1步，再通过输入锥扩展1步，限制为VBUF
+select t:VBUF %co1:+[O] %ci1:+[I],VBUF t:VBUF %i
+
+# 如果需要确保中间没有其他器件，可以添加额外的约束
+# 方法4：检查直接连接（无中间器件）
+select t:VBUF %x1:+[O] w:* %x1:+[I],VBUF t:VBUF %i
+
+# 注意：%x1 表示只扩展1步，确保是直接连接
+# +[O] 表示只通过输出端口O扩展
+# +[I],VBUF 表示只通过VBUF器件的输入端口I扩展
+
+# 最终推荐的完整解决方案：
+echo "查找VBUF器件实例，其输入端口I直接连接到另一个VBUF的输出端口O："
+select t:VBUF %x1:+[O] w:* %x1:+[I],VBUF t:VBUF %i

--- a/vbuf_test.v
+++ b/vbuf_test.v
@@ -1,0 +1,30 @@
+// VBUF模块定义
+(* blackbox=1 *)
+module VBUF (O, I);
+    output O;
+    input  I;
+endmodule
+
+// 测试模块，包含多种VBUF连接情况
+module test_vbuf_connections;
+    wire net1, net2, net3, net4, net5, net6;
+    wire input_sig, output_sig;
+    
+    // 情况1：直接连接的VBUF链 - vbuf1的输出连接到vbuf2的输入
+    VBUF vbuf1 (.I(input_sig), .O(net1));
+    VBUF vbuf2 (.I(net1), .O(net2));        // 这个应该被选中
+    
+    // 情况2：另一个直接连接的VBUF链
+    VBUF vbuf3 (.I(net2), .O(net3));        // 这个也应该被选中
+    VBUF vbuf4 (.I(net3), .O(output_sig));  // 这个也应该被选中
+    
+    // 情况3：独立的VBUF，没有连接到其他VBUF
+    VBUF vbuf5 (.I(input_sig), .O(net4));   // 这个不应该被选中（输出没连到其他VBUF）
+    
+    // 情况4：输入没有连接到其他VBUF的输出
+    VBUF vbuf6 (.I(net5), .O(net6));        // 这个不应该被选中（输入没连到其他VBUF输出）
+    
+    // 假设net5来自其他源，不是VBUF的输出
+    assign net5 = input_sig;
+    
+endmodule


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
This change provides a Yosys `select` command to identify VBUF instances whose input port `I` is directly connected to another VBUF's output port `O`, with no intermediate components. This addresses a specific user request for complex cell connectivity queries.

_Explain how this is achieved._
A Yosys `select` command (`select t:VBUF %x1:+[O] w:* %x1:+[I],VBUF t:VBUF %i`) is used. This command leverages Yosys's graph traversal capabilities (`%x1` for single-step extension) and port/type filtering (`+[O]`, `+[I],VBUF`, `t:VBUF`) to precisely match the required connectivity pattern. Supporting Verilog and Yosys scripts are included to demonstrate and test the solution.

_If applicable, please suggest to reviewers how they can test the change._
To test, run the `test_vbuf_select.ys` script using Yosys:
```bash
yosys -s test_vbuf_select.ys
```
The script will load `vbuf_test.v` and execute the `select` command, printing the selected VBUF instances (expected: `vbuf2`, `vbuf3`, `vbuf4`).

---
<a href="https://cursor.com/background-agent?bcId=bc-ce34face-ef1b-4ce5-b228-db10a1afb9de">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ce34face-ef1b-4ce5-b228-db10a1afb9de">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>