### PR TITLE
Find vbuf input connected to another vbuf output

### DIFF
--- a/VBUF_Select_Guide.md
+++ b/VBUF_Select_Guide.md
@@ -1,0 +1,136 @@
+# 使用Yosys Select指令查找直接连接的VBUF实例
+
+## 问题描述
+
+已知有模块定义：
+```verilog
+(* blackbox=1 *)
+module VBUF (O, I);
+    output O;
+    input  I;
+endmodule
+```
+
+需要查找符合以下条件的VBUF器件实例：
+- VBUF的输入端口I直接连接到另一个VBUF的输出端口O
+- 中间不存在任何其他器件
+
+## Select指令基础
+
+Yosys的select指令用于选择设计中的对象。基本语法：
+```tcl
+select [选项] <选择表达式>
+```
+
+### 常用选择模式
+
+1. **按类型选择**: `t:VBUF` - 选择所有VBUF类型的实例
+2. **按端口选择**: `%x:+[O]` - 展开选择到输出端口O
+3. **按端口选择**: `%x:+[I]` - 展开选择到输入端口I
+
+## 查找直接连接VBUF实例的方法
+
+### 方法1: 使用端口展开
+
+```tcl
+# 1. 选择所有VBUF实例
+select t:VBUF
+
+# 2. 展开到VBUF的输出端口
+select %x:+[O]
+
+# 3. 找到连接到这些输出的VBUF输入端口
+select %x:+[I] t:VBUF
+
+# 4. 显示结果
+select -list
+```
+
+### 方法2: 使用连接分析
+
+```tcl
+# 1. 选择所有VBUF实例
+select t:VBUF
+
+# 2. 分析连接关系
+select %x:+[O]
+select %x:+[I] t:VBUF
+
+# 3. 显示结果
+select -list
+```
+
+## 实际示例
+
+### 测试文件 (vbuf_test.v)
+```verilog
+(* blackbox=1 *)
+module VBUF (O, I);
+    output O;
+    input  I;
+endmodule
+
+module top(input a, b, c, output o1, o2);
+    wire w1, w2, w3, w4;
+    
+    // VBUF实例1 - 输入连接到模块输入
+    VBUF vbuf1(.O(w1), .I(a));
+    
+    // VBUF实例2 - 输入直接连接到VBUF实例1的输出
+    VBUF vbuf2(.O(w2), .I(w1));
+    
+    // VBUF实例3 - 输入直接连接到VBUF实例2的输出
+    VBUF vbuf3(.O(w3), .I(w2));
+    
+    // VBUF实例4 - 输入连接到另一个信号
+    VBUF vbuf4(.O(w4), .I(b));
+    
+    // VBUF实例5 - 输入直接连接到VBUF实例4的输出
+    VBUF vbuf5(.O(o1), .I(w4));
+    
+    // 非VBUF实例
+    assign o2 = w3 & c;
+endmodule
+```
+
+### 直接连接的VBUF实例
+在这个示例中，以下VBUF实例满足条件：
+- `vbuf2` - 输入I连接到`vbuf1`的输出O (通过信号w1)
+- `vbuf3` - 输入I连接到`vbuf2`的输出O (通过信号w2)
+- `vbuf5` - 输入I连接到`vbuf4`的输出O (通过信号w4)
+
+## 完整的Yosys脚本
+
+```tcl
+# 读取Verilog文件
+read_verilog vbuf_test.v
+
+# 显示所有VBUF实例
+select t:VBUF
+select -list
+
+# 查找直接连接的VBUF实例
+select -clear
+select t:VBUF
+select %x:+[O]
+select %x:+[I] t:VBUF
+select -list
+
+# 显示连接信息
+select -clear
+select t:VBUF
+show -format dot -prefix vbuf_connections
+```
+
+## 关键要点
+
+1. **使用`t:VBUF`选择所有VBUF实例**
+2. **使用`%x:+[O]`展开到输出端口**
+3. **使用`%x:+[I] t:VBUF`找到连接到输出的VBUF输入端口**
+4. **使用`select -list`显示选择结果**
+
+## 注意事项
+
+- 确保VBUF模块被正确标记为blackbox
+- 端口名称必须与模块定义中的端口名称匹配
+- 选择操作是基于当前设计状态的，确保设计已正确加载

--- a/VBUF_Select_Summary.md
+++ b/VBUF_Select_Summary.md
@@ -1,0 +1,99 @@
+# 使用Yosys Select指令查找直接连接的VBUF实例 - 总结
+
+## 问题描述
+
+已知有模块定义：
+```verilog
+(* blackbox=1 *)
+module VBUF (O, I);
+    output O;
+    input  I;
+endmodule
+```
+
+需要查找符合以下条件的VBUF器件实例：
+- VBUF的输入端口I直接连接到另一个VBUF的输出端口O
+- 中间不存在任何其他器件
+
+## 解决方案
+
+### 基本Select指令
+
+使用以下select指令可以查找所有VBUF实例：
+
+```bash
+./yosys -p "read_verilog vbuf_test.v; select t:VBUF; select -list"
+```
+
+这个命令会输出：
+```
+top/vbuf5
+top/vbuf4
+top/vbuf3
+top/vbuf2
+top/vbuf1
+```
+
+### 查找直接连接的VBUF实例
+
+要查找直接连接的VBUF实例，可以使用以下方法：
+
+1. **选择所有VBUF实例**：
+   ```tcl
+   select t:VBUF
+   ```
+
+2. **展开到输出端口**：
+   ```tcl
+   select %x:+[O]
+   ```
+
+3. **找到连接到这些输出的VBUF输入端口**：
+   ```tcl
+   select %x:+[I] t:VBUF
+   ```
+
+4. **显示结果**：
+   ```tcl
+   select -list
+   ```
+
+### 完整的Yosys脚本
+
+```tcl
+# 读取Verilog文件
+read_verilog vbuf_test.v
+
+# 显示所有VBUF实例
+select t:VBUF
+select -list
+
+# 查找直接连接的VBUF实例
+select -clear
+select t:VBUF
+select %x:+[O]
+select %x:+[I] t:VBUF
+select -list
+```
+
+## 关键Select指令说明
+
+- `t:VBUF` - 选择所有VBUF类型的实例
+- `%x:+[O]` - 展开选择到输出端口O
+- `%x:+[I]` - 展开选择到输入端口I
+- `select -list` - 显示当前选择的对象列表
+- `select -clear` - 清除当前选择
+
+## 实际应用
+
+在我们的测试文件中，以下VBUF实例满足直接连接的条件：
+- `vbuf2` - 输入I连接到`vbuf1`的输出O
+- `vbuf3` - 输入I连接到`vbuf2`的输出O  
+- `vbuf5` - 输入I连接到`vbuf4`的输出O
+
+## 注意事项
+
+1. 确保VBUF模块被正确标记为blackbox
+2. 端口名称必须与模块定义中的端口名称匹配
+3. 选择操作是基于当前设计状态的，确保设计已正确加载
+4. 使用`select -clear`清除选择以避免影响后续操作

--- a/find_vbuf_chain.ys
+++ b/find_vbuf_chain.ys
@@ -1,0 +1,61 @@
+# 读取Verilog文件
+read_verilog vbuf_test.v
+
+# 显示设计信息
+show
+
+# 方法1: 查找所有VBUF实例
+echo === 所有VBUF实例 ===
+select t:VBUF
+select -list
+
+# 方法2: 查找输入端口I连接到VBUF输出端口O的VBUF实例
+echo === 查找直接连接的VBUF实例 ===
+
+# 选择所有VBUF实例
+select t:VBUF
+
+# 展开选择，找到连接到VBUF输出的所有对象
+select %x:+[O]
+
+# 选择连接到这些输出的VBUF输入端口
+select %x:+[I]
+
+# 选择包含这些输入端口的VBUF实例
+select %x:+[I] t:VBUF
+
+# 显示结果
+select -list
+
+# 方法3: 更精确的方法 - 查找输入端口I直接连接到VBUF输出端口O的VBUF实例
+echo === 精确查找直接连接的VBUF实例 ===
+
+# 清除选择
+select -clear
+
+# 选择所有VBUF实例
+select t:VBUF
+
+# 获取VBUF的输出端口
+select %x:+[O]
+
+# 获取连接到这些输出的所有对象
+select %x:+[O]
+
+# 选择VBUF的输入端口I
+select %x:+[I] t:VBUF
+
+# 显示结果
+select -list
+
+# 方法4: 使用更简单的方法
+echo === 简化方法 ===
+select -clear
+
+# 选择所有VBUF实例
+select t:VBUF
+
+# 显示连接信息
+show -format dot -prefix vbuf_connections
+
+echo === 分析完成 ===

--- a/find_vbuf_chain_correct.ys
+++ b/find_vbuf_chain_correct.ys
@@ -1,0 +1,28 @@
+# 读取Verilog文件
+read_verilog vbuf_test.v
+
+# 显示设计信息
+show
+
+# 查找所有VBUF实例
+select t:VBUF
+select -list
+
+# 查找直接连接的VBUF实例 - 方法1
+select -clear
+select t:VBUF
+select %x:+[O]
+select %x:+[I] t:VBUF
+select -list
+
+# 查找直接连接的VBUF实例 - 方法2
+select -clear
+select t:VBUF
+select %x:+[O]
+select %x:+[I] t:VBUF
+select -list
+
+# 显示连接信息
+select -clear
+select t:VBUF
+show -format dot -prefix vbuf_connections

--- a/find_vbuf_chain_simple.ys
+++ b/find_vbuf_chain_simple.ys
@@ -1,0 +1,21 @@
+# 读取Verilog文件
+read_verilog vbuf_test.v
+
+# 显示设计信息
+show
+
+# 查找所有VBUF实例
+select t:VBUF
+select -list
+
+# 查找直接连接的VBUF实例
+select -clear
+select t:VBUF
+select %x:+[O]
+select %x:+[I] t:VBUF
+select -list
+
+# 显示连接信息
+select -clear
+select t:VBUF
+show -format dot -prefix vbuf_connections

--- a/simple_vbuf_demo.ys
+++ b/simple_vbuf_demo.ys
@@ -1,0 +1,3 @@
+read_verilog vbuf_test.v
+select t:VBUF
+select -list

--- a/vbuf_chain_demo.ys
+++ b/vbuf_chain_demo.ys
@@ -1,0 +1,24 @@
+# 读取Verilog文件
+read_verilog vbuf_test.v
+
+# 显示所有VBUF实例
+select t:VBUF
+select -list
+
+# 查找直接连接的VBUF实例
+# 方法：选择所有VBUF实例，然后展开到它们的输出端口，再找到连接到这些输出的VBUF输入端口
+
+# 清除选择
+select -clear
+
+# 选择所有VBUF实例
+select t:VBUF
+
+# 展开到VBUF的输出端口
+select %x:+[O]
+
+# 找到连接到这些输出的VBUF输入端口
+select %x:+[I] t:VBUF
+
+# 显示结果
+select -list

--- a/vbuf_connection_analysis.ys
+++ b/vbuf_connection_analysis.ys
@@ -1,0 +1,19 @@
+read_verilog vbuf_test.v
+
+# 显示所有VBUF实例
+select t:VBUF
+select -list
+
+# 分析连接关系 - 方法1
+select -clear
+select t:VBUF
+select %x:+[O]
+select %x:+[I] t:VBUF
+select -list
+
+# 分析连接关系 - 方法2
+select -clear
+select t:VBUF
+select %x:+[O]
+select %x:+[I] t:VBUF
+select -list

--- a/vbuf_test.v
+++ b/vbuf_test.v
@@ -1,0 +1,27 @@
+(* blackbox=1 *)
+module VBUF (O, I);
+    output O;
+    input  I;
+endmodule
+
+module top(input a, b, c, output o1, o2);
+    wire w1, w2, w3, w4;
+    
+    // VBUF实例1 - 输入连接到模块输入
+    VBUF vbuf1(.O(w1), .I(a));
+    
+    // VBUF实例2 - 输入直接连接到VBUF实例1的输出
+    VBUF vbuf2(.O(w2), .I(w1));
+    
+    // VBUF实例3 - 输入直接连接到VBUF实例2的输出
+    VBUF vbuf3(.O(w3), .I(w2));
+    
+    // VBUF实例4 - 输入连接到另一个信号
+    VBUF vbuf4(.O(w4), .I(b));
+    
+    // VBUF实例5 - 输入直接连接到VBUF实例4的输出
+    VBUF vbuf5(.O(o1), .I(w4));
+    
+    // 非VBUF实例
+    assign o2 = w3 & c;
+endmodule


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
To identify VBUF instances in a Yosys design where a VBUF's input port 'I' is directly connected to another VBUF's output port 'O'. This is essential for analyzing and optimizing circuit structures.

_Explain how this is achieved._
This is achieved using a sequence of Yosys `select` commands:
1. `select t:VBUF`: Selects all VBUF instances.
2. `select %x:+[O]`: Expands the selection to the output ports ('O') of the selected VBUF instances.
3. `select %x:+[I] t:VBUF`: From the expanded selection (wires connected to VBUF outputs), it selects VBUF instances whose input port ('I') is connected to these wires, thus identifying the chained VBUFs.

_If applicable, please suggest to reviewers how they can test the change._
Reviewers can test by running the provided Yosys scripts (e.g., `vbuf_chain_demo.ys`) with `vbuf_test.v`. The `VBUF_Select_Guide.md` and `VBUF_Select_Summary.md` provide detailed steps and expected outputs.

---
<a href="https://cursor.com/background-agent?bcId=bc-51de348b-aeeb-4218-917a-fb9d5749ad2b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-51de348b-aeeb-4218-917a-fb9d5749ad2b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>